### PR TITLE
Support Dependency Requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "illuminate/console": "^9.0",
-        "illuminate/filesystem": "^9.0",
-        "illuminate/support": "^9.0"
+        "php": "^8.0",
+        "illuminate/console": "^9.0|^10.0",
+        "illuminate/filesystem": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/console": "^8.0",
+        "illuminate/console": "^9.0",
         "illuminate/filesystem": "^8.0",
         "illuminate/support": "^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "require": {
         "php": "^7.3|^8.0",
         "illuminate/console": "^9.0",
-        "illuminate/filesystem": "^8.0",
-        "illuminate/support": "^8.0"
+        "illuminate/filesystem": "^9.0",
+        "illuminate/support": "^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR is submitted to support a more update dependency requirement.

We have a project tape-giz, it needs to run R script and R markdown.
Package laravel-r-setup version 1.01 cannot be installed in tape-giz due to package conflicts.

Considering project tape-giz is using Laravel 9, I have updated illuminate related packages from version 8.0 to 9.0.
I pushed latest code to branch "support-latest-dependencies", then I can install laravel-r-setup for branch "support-latest-dependencies" successfully in tape-giz project with below command:

composer require stats4sd/laravel-r-setup:dev-support-latest-dependencies

---

```
PS C:\public\tape-giz> composer require stats4sd/laravel-r-setup:dev-support-latest-dependencies
Failed loading C:\php\ext\php_xdebug.dll
Info from https://repo.packagist.org: #StandWithUkraine
./composer.json has been updated
Running composer update stats4sd/laravel-r-setup
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking stats4sd/laravel-r-setup (dev-support-latest-dependencies 5a26f8e)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Downloading stats4sd/laravel-r-setup (dev-support-latest-dependencies 5a26f8e)
  - Installing stats4sd/laravel-r-setup (dev-support-latest-dependencies 5a26f8e): Extracting archive
Package fruitcake/laravel-cors is abandoned, you should avoid using it. No replacement was suggested.
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi
Failed loading C:\php\ext\php_xdebug.dll

   INFO  Discovering packages.

  backpack/crud ............................................................................................................................... DONE
  backpack/generators ......................................................................................................................... DONE
  backpack/permissionmanager .................................................................................................................. DONE
  backpack/pro ................................................................................................................................ DONE
  barryvdh/laravel-ide-helper ................................................................................................................. DONE
  creativeorange/gravatar ..................................................................................................................... DONE
  digitallyhappy/assets ....................................................................................................................... DONE
  fideloper/proxy ............................................................................................................................. DONE
  fruitcake/laravel-cors ...................................................................................................................... DONE
  intervention/image .......................................................................................................................... DONE
  laravel/sail ................................................................................................................................ DONE
  laravel/telescope ........................................................................................................................... DONE
  laravel/tinker .............................................................................................................................. DONE
  livewire/livewire ........................................................................................................................... DONE
  maatwebsite/excel ........................................................................................................................... DONE
  nesbot/carbon ............................................................................................................................... DONE
  nunomaduro/collision ........................................................................................................................ DONE
  orangehill/iseed ............................................................................................................................ DONE
  prologue/alerts ............................................................................................................................. DONE
  simplesoftwareio/simple-qrcode .............................................................................................................. DONE
  spatie/laravel-ignition ..................................................................................................................... DONE
  spatie/laravel-permission ................................................................................................................... DONE
  stats4sd/laravel-file-util .................................................................................................................. DONE
  stats4sd/laravel-odk-link ................................................................................................................... DONE
  stats4sd/laravel-sql-views .................................................................................................................. DONE
  stats4sd/laravel-team-management ............................................................................................................ DONE

103 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found
PS C:\public\tape-giz>

```

---

After merging this PR into main branch, I will create a new version 1.02 and publish it to packagist.

---

In near future, we may need to have another version to support Laravel 10.

